### PR TITLE
WH-53: Team editing abilities

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -38,11 +38,18 @@ export default function Button(props) {
 
     return (
         <>
-            <a href={link}>
+            { props.link && 
+                <a href={link}>
+                    <button className={styles.button} style={propStyles} onClick={props.onClick}>
+                        {props.name}
+                    </button>
+                </a>
+            }
+            { !props.link && 
                 <button className={styles.button} style={propStyles} onClick={props.onClick}>
                     {props.name}
                 </button>
-            </a>
+            }
         </>
     )
 }

--- a/src/components/button/button.module.css
+++ b/src/components/button/button.module.css
@@ -6,5 +6,9 @@
     padding-bottom: 12px;
     border: none;
     font-size: 14px;
-    /* TODO: Add hover, click, active, etc. */
+    cursor:pointer;
+}
+
+.button:active {
+    background-color: #2e2e2e;
 }

--- a/src/pages/teamsanduniversities/team/team.js
+++ b/src/pages/teamsanduniversities/team/team.js
@@ -25,38 +25,100 @@ const Team = (props) => {
 
   let { id } = useParams();
 
-    return (
-          <>
-            <Header 
-              name={teamNamePrefix + teamName}
-            />
+  // edit team name
+  function teamNameEditOnSubmit (e) {
+    /**
+     * TODO: check for default value, check string not empty
+     *       strip value, check for bad input...
+     */
+    e.preventDefault();
+    alert(e.target.teamName.value);
+  }
 
-          <div className={`${globalStyles.grid_page} ${globalStyles.body_margin} ${globalStyles.margin8_top_bottom}`}>
-            <h3 className={`${globalStyles.text} ${styles.university}`}>Dynamic University Name TODO</h3>
+  function teamProfilePictureEditOnSubmit (e) {
+    /**
+     * TODO: check for image size, check for no image
+     *       check image type, ...
+     */
+    e.preventDefault();
+    alert("Submit clicked");
+  }
+  
+  function teamRosterEditOnSubmit (e) {
+    // TODO
+    e.preventDefault();
+  }
 
-            <div className={globalStyles.grid}>
-                {/* Team Members */}
-                {
-                    // eslint-disable-next-line
-                    members.map((member) => {
-                        return (
-                            <MemberBlock member={member} />
-                        )
-                    })
-                }
-            </div>
+  return (
+        <>
+          <Header 
+            name={teamNamePrefix + teamName}
+          />
 
-            { teamID == id &&
-              <div className={styles.editButtonRow}>
-                <Button name='Edit Team Name' />
-                <Button name='Edit Team Profile Picture' />
-                <Button name='Edit Roster' />
-              </div>
-            }
+        <div className={`${globalStyles.grid_page} ${globalStyles.body_margin} ${globalStyles.margin8_top_bottom}`}>
+          <h3 className={`${globalStyles.text} ${styles.university}`}>Dynamic University Name TODO</h3>
 
+          <div className={globalStyles.grid}>
+              {/* Team Members */}
+              {
+                  // eslint-disable-next-line
+                  members.map((member) => {
+                      return (
+                          <MemberBlock member={member} />
+                      )
+                  })
+              }
           </div>
-        </>
-    )
+
+          { teamID == id &&
+            <div className={styles.editButtonRow}>
+              <Button name='Edit Team Name' />
+              <Button name='Edit Team Profile Picture' />
+              <Button name='Edit Roster' />
+            </div>
+          }
+
+          <hr/>
+          <form className={styles.editTeamNameForm} onSubmit={teamNameEditOnSubmit}>
+            <h5>Has prefix "Team " (with space)</h5>
+            <input defaultValue={teamName} name='teamName' placeholder='Team Name'/><br/>
+            <Button name='Cancel' />
+            <Button type='submit' name='Save' />
+          </form>
+          
+          <hr/>
+          <form className={styles.editTeamProfilePicture} onSubmit={teamProfilePictureEditOnSubmit}>
+            <h5>Change profile picture (or default will be provided)</h5>
+            <input type="file" name="teamProfilePicture" accept="image/*" /><br/>
+            <Button name='Cancel' />
+            <Button type='submit' name='Save' />
+            <br/>
+            {/* TODO: Add confirm button */}
+            <Button type='submit' name='Delete Exisiting Photo' /> 
+          </form>
+
+
+          <hr/>
+          <h5>Current Roster</h5>
+          {
+            // eslint-disable-next-line
+            members.map(member => {
+              return (
+                <>
+                  <div>{member.name}</div><Button name='Remove' onClick={function () { alert(`Removing user ${member.name}`); } } /><br />
+                </>
+              )
+            })
+          }
+          <form className={styles.editTeamRosterForm} onSubmit={teamRosterEditOnSubmit}>
+            <h5>Add to Roster by Email</h5>
+            <input type='email' placeholder='Email'/>
+            <Button type='submit' name='Request user join roster' />
+          </form>
+
+        </div>
+      </>
+  )
 };
   
 export default Team;

--- a/src/pages/teamsanduniversities/team/team.js
+++ b/src/pages/teamsanduniversities/team/team.js
@@ -70,7 +70,7 @@ const Team = (props) => {
               }
           </div>
 
-          { teamID == id &&
+          { teamID === id &&
             <div className={styles.editButtonRow}>
               <Button name='Edit Team Name' />
               <Button name='Edit Team Profile Picture' />

--- a/src/pages/teamsanduniversities/team/team.js
+++ b/src/pages/teamsanduniversities/team/team.js
@@ -3,7 +3,7 @@ import image from '../../../components/placeholder.png';
 import { useParams } from "react-router-dom";
 import globalStyles from '../../pages.module.css';
 import styles from './team.module.css';
-
+import Button from '../../../components/button/button';
 import Header from '../../../components/header/header';
 import MemberBlock from '../../../components/memberblock/memberblock';
 
@@ -18,16 +18,21 @@ const members = [
 
 const Team = (props) => {   
 
+  // TEMP HARDCODED
+  const teamID = "1"; // acting as a substitute for a user's team ID
+  let teamNamePrefix = "Team ";
+  let teamName = "Temp Name"; // acting as a substitute for a team's name
+
   let { id } = useParams();
 
     return (
           <>
             <Header 
-              name={`Team with ID: ${id}`}
+              name={teamNamePrefix + teamName}
             />
 
           <div className={`${globalStyles.grid_page} ${globalStyles.body_margin} ${globalStyles.margin8_top_bottom}`}>
-            <h3 className={`${globalStyles.text} ${styles.university}`}> University Name</h3>
+            <h3 className={`${globalStyles.text} ${styles.university}`}>Dynamic University Name TODO</h3>
 
             <div className={globalStyles.grid}>
                 {/* Team Members */}
@@ -40,6 +45,15 @@ const Team = (props) => {
                     })
                 }
             </div>
+
+            { teamID == id &&
+              <div className={styles.editButtonRow}>
+                <Button name='Edit Team Name' />
+                <Button name='Edit Team Profile Picture' />
+                <Button name='Edit Roster' />
+              </div>
+            }
+
           </div>
         </>
     )

--- a/src/pages/teamsanduniversities/team/team.js
+++ b/src/pages/teamsanduniversities/team/team.js
@@ -72,34 +72,31 @@ const Team = (props) => {
 
           { teamID === id &&
             <div className={styles.editButtonRow}>
-              <Button name='Edit Team Name' />
+              <Button name='Edit Team Name' onClick={function() { document.getElementsByClassName(styles.editTeamNameForm)[0].style.display = "block"; }} />
               <Button name='Edit Team Profile Picture' />
               <Button name='Edit Roster' />
             </div>
           }
 
-          <hr/>
           <form className={styles.editTeamNameForm} onSubmit={teamNameEditOnSubmit}>
             <h5>Has prefix "Team " (with space)</h5>
             <input defaultValue={teamName} name='teamName' placeholder='Team Name'/><br/>
-            <Button name='Cancel' />
-            <Button type='submit' name='Save' />
+            <Button onClick={function(e) {e.preventDefault(); document.getElementsByClassName(styles.editTeamNameForm)[0].style.display = "none"; }} name='Cancel' />
+            <Button name='Save' />
           </form>
           
-          <hr/>
-          <form className={styles.editTeamProfilePicture} onSubmit={teamProfilePictureEditOnSubmit}>
+          {/* <form className={styles.editTeamProfilePicture} onSubmit={teamProfilePictureEditOnSubmit}>
             <h5>Change profile picture (or default will be provided)</h5>
             <input type="file" name="teamProfilePicture" accept="image/*" /><br/>
             <Button name='Cancel' />
             <Button type='submit' name='Save' />
-            <br/>
+            <br/> */}
             {/* TODO: Add confirm button */}
-            <Button type='submit' name='Delete Exisiting Photo' /> 
-          </form>
+            {/* <Button type='submit' name='Delete Exisiting Photo' /> 
+          </form> */}
 
 
-          <hr/>
-          <h5>Current Roster</h5>
+          {/* <h5>Current Roster</h5>
           {
             // eslint-disable-next-line
             members.map(member => {
@@ -114,7 +111,7 @@ const Team = (props) => {
             <h5>Add to Roster by Email</h5>
             <input type='email' placeholder='Email'/>
             <Button type='submit' name='Request user join roster' />
-          </form>
+          </form> */}
 
         </div>
       </>

--- a/src/pages/teamsanduniversities/team/team.module.css
+++ b/src/pages/teamsanduniversities/team/team.module.css
@@ -9,3 +9,7 @@
 .editButtonRow > * {
     margin-right: 16px;
 }
+
+.editTeamNameForm {
+    display: none;
+}

--- a/src/pages/teamsanduniversities/team/team.module.css
+++ b/src/pages/teamsanduniversities/team/team.module.css
@@ -1,3 +1,11 @@
 .university {
     margin-bottom: 2vh;
 }
+
+.editButtonRow {
+    margin-top: 24px;
+}
+
+.editButtonRow > * {
+    margin-right: 16px;
+}


### PR DESCRIPTION
- [ ] Ability to add/edit/remove team image/logo
- [ ] Ability to add/edit/remove players from team
- [ ] Ability to add/edit/remove team description (?)
- [ ] “Create A Team” page — do we have one? Thinking we need one…
- [ ] Row of CRUD buttons at bottom of team page appears if user is a part of team (can be determined with fetch request in case cookie is stale)
- [ ] Edit Roster button
  - [x] brings up form to add/remove user to current team by email
  - [ ] would user being added need to accept this request to join team?
  - [ ] remove only works if it’s done by team creator?
- [ ] Edit Team Profile Picture
  - [x] Brings up form for file drag and drop for new team image
  - [x] form also contains option to delete existing image
- [ ] Edit Team Name
  - [x] Brings up form for editing team name
- [ ] Edit Team Description (?)
  - [ ] Brings up a form for editing team description